### PR TITLE
fix special characters "\" in html is replaced by "" when build

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ class TemplateCachePlugin {
                 source = source.toString();
                 source = htmlMinifier.minify(source, minifyOptions);
                 source = source.replace(/\r?\n|\r/g, "");
+                source = source.replace(/\\/g, "\\\\");
                 source = source.replace(/'/g, "\\'");
                 source = source.replace(/"/g, "\\\"");
                 // remove basefolder we dont want to have in path


### PR DESCRIPTION
**html template**
`<input type="text" name="mobile" ng-pattern="^\d{10}$"/>`

**after webpack build "\\" is missing**
`<input type="text" name="mobile" ng-pattern="^d{10}$"/>`

**correct build**
`<input type="text" name="mobile" ng-pattern="^\\d{10}$"/>`

